### PR TITLE
Lambda python manage script fixes

### DIFF
--- a/deployment/manage_asserts_layer.py
+++ b/deployment/manage_asserts_layer.py
@@ -44,7 +44,7 @@ variables = {
 host = 'ASSERTS_METRICSTORE_HOST'
 tenant_name = 'ASSERTS_TENANT_NAME'
 password = 'ASSERTS_PASSWORD'
-env = 'ASSERTS_ENV'
+env = 'ASSERTS_ENVIRONMENT'
 
 if operation in 'add-layer' and config.get(host) is None:
     print("Config file 'config.yml' is invalid. '" + host + "' is not specified")

--- a/deployment/sample-config.yml
+++ b/deployment/sample-config.yml
@@ -10,7 +10,7 @@ ASSERTS_METRICSTORE_HOST: https://chief.tsdb.dev.asserts.ai/api/v1/import/promet
 # ASSERTS_TENANT and ASSERTS_PASSWORD are optional
 ASSERTS_TENANT_NAME: chief
 ASSERTS_PASSWORD: wrong
-ASSERTS_ENV: dev
+ASSERTS_ENVIRONMENT: dev
 
 # Functions can be specified either through a regex pattern or through a list of function names
 # function_name_pattern: Sample.+


### PR DESCRIPTION
Remove layer function to remove the AWS environment variable
config to support assert env variable.
[ch11261]